### PR TITLE
atualização 2.2.4

### DIFF
--- a/pgh_hgm--2.2.3.sql
+++ b/pgh_hgm--2.2.3.sql
@@ -41,7 +41,7 @@
 */
 
 ---------------------------------------------------------------------------------
---PGH_HGM: PgHydro Hydrological Geomorphology Calculations Extension - v.2.2.3 (2023.10.30)
+--PGH_HGM: PgHydro Hydrological Geomorphology Calculations Extension - v.2.2.3 (2024.01.09)
 ---------------------------------------------------------------------------------
 
 -------------------------------------
@@ -1764,7 +1764,7 @@ BEGIN
                 tc_dooge,
                 tc_kirpich,
                 tc_wattchow,
-                tc_georgeribeiro
+                tc_georgeribeiro,
                 tc_pasini,
                 tc_ventura,
                 tc_dnosk1                
@@ -6246,9 +6246,9 @@ BEGIN
             57.0 * (hig_drn_length_km^3. / (hig_drn_slope_adim*hig_drn_length_km*1000.))^0.385 AS tc_kirpich,
             7.68*(hig_drn_length_km/(hig_drn_slope_adim^0.5))^0.79 AS tc_wattchow,
             16.*hig_drn_length_km/(1.05-0.2*(0.6))*(100.*hig_drn_slope_adim)^0.04 AS tc_georgeribeiro, --assuming p=0.6   
-            (60)*0.107*(hig_dra_area_km2*hig_drn_length_km)^(1./3.)/((100.*hig_drn_slope_adim)^0.5) AS tc_pasini,
-            (60)*0.127*SQRT(hig_dra_area_km2/(100.*hig_drn_slope_adim)) AS tc_ventura,
-            10./(1.0)*(hig_dra_area_km2^0.3)*(hig_drn_length_km^0.2)/((100.*hig_drn_slope_adim)^0.4) AS tc_dnosk1 --assume K=1                  
+            (60)*0.107*(hig_dra_area_km2*hig_drn_length_km)^(1./3.)/((hig_drn_slope_adim)^0.5) AS tc_pasini,
+            (60)*0.127*SQRT(hig_dra_area_km2/(hig_drn_slope_adim)) AS tc_ventura,
+            10./(1.0)*(hig_dra_area_km2^0.3)*(hig_drn_length_km^0.2)/((hig_drn_slope_adim)^0.4) AS tc_dnosk1 --assume K=1                  
         FROM
             pgh_hgm.pghft_hydro_intel
         WHERE hig_dra_pk = dra_pk_;
@@ -9120,9 +9120,9 @@ BEGIN
             57.0 * (hig_upn_length_km^3. / (hig_upn_slope_adim*hig_upn_length_km*1000.))^0.385 AS tc_kirpich,
             7.68*(hig_upn_length_km/(hig_upn_slope_adim^0.5))^0.79 AS tc_wattchow,
             16.*hig_upn_length_km/(1.05-0.2*(0.6))*(100.*hig_upn_slope_adim)^0.04 AS tc_georgeribeiro, --assuming p=0.6
-            (60)*0.107*(hig_upa_area_km2*hig_upn_length_km)^(1./3.)/((100.*hig_upn_slope_adim)^0.5) AS tc_pasini,
-            (60)*0.127*SQRT(hig_upa_area_km2/(100.*hig_upn_slope_adim)) AS tc_ventura,
-            10./(1.0)*(hig_upa_area_km2^0.3)*(hig_upn_length_km^0.2)/((100.*hig_upn_slope_adim)^0.4) AS tc_dnosk1 --assume K=1        
+            (60)*0.107*(hig_upa_area_km2*hig_upn_length_km)^(1./3.)/((hig_upn_slope_adim)^0.5) AS tc_pasini,
+            (60)*0.127*SQRT(hig_upa_area_km2/(hig_upn_slope_adim)) AS tc_ventura,
+            10./(1.0)*(hig_upa_area_km2^0.3)*(hig_upn_length_km^0.2)/((hig_upn_slope_adim)^0.4) AS tc_dnosk1 --assume K=1        
         FROM
             pgh_hgm.pghft_hydro_intel
         WHERE hig_dra_pk = dra_pk_;

--- a/pgh_hgm--2.2.3.sql
+++ b/pgh_hgm--2.2.3.sql
@@ -622,9 +622,15 @@ $BODY$
         hig_dra_area_, hig_dra_area_km2, hig_dra_perimeter_, hig_dra_perimeter_km, hig_dra_axislength, hig_dra_circularity, hig_dra_compacity, hig_dra_shapefactor, hig_dra_formfactor, hig_drn_sinuosity, hig_dra_reliefratio, hig_dra_reachgradient, hig_dra_elevation_avg, hig_dra_elevation_max, hig_dra_elevation_min, hig_dra_elevationdrop_m, hig_dra_drainagedensity, hig_dra_hydrodensity, hig_dra_avglengthoverlandflow,
         hig_drn_length_, hig_drn_length_km, hig_drn_depth_m, hig_drn_width_m, hig_drn_elevationdrop_m, hig_drn_slope_adim, hig_drn_manning_n, hig_drn_velmann, hig_drn_celmann, hig_drn_trlmann, hig_drn_velmann_lr, hig_drn_celmann_lr, hig_drn_trlmann_lr, hig_drn_celdyna, hig_drn_trldyna,
         hig_upa_area_, hig_upa_area_km2, hig_upa_perimeter_, hig_upa_perimeter_km, hig_upa_drainagedensity, hig_upa_hydrodensity, hig_upa_avglengthoverlandflow, hig_upa_totaldrainagelength, hig_upa_axislength, hig_upa_circularity, hig_upa_compacity, hig_upa_shapefactor, hig_upa_formfactor, hig_upn_sinuosity, hig_upa_elevation_avg, hig_upa_elevation_max, hig_upa_elevation_min, hig_upa_elevationdrop_m, hig_upa_reliefratio, hig_upa_reachgradient,
+        
         hig_dra_tc_kirpich, hig_dra_tc_dooge, hig_dra_tc_carter, hig_dra_tc_armycorps, hig_dra_tc_wattchow,
-        hig_upa_tc_kirpich, hig_upa_tc_dooge, hig_upa_tc_carter, hig_upa_tc_armycorps, hig_upa_tc_wattchow,
-        hig_upn_elevation_avg, hig_upn_elevation_max, hig_upn_elevation_min, hig_upn_length_, hig_upn_length_km, hig_upn_elevationdrop_m, hig_upn_slope_adim, hig_upn_slope_maxmin, hig_upn_slope_s1585, hig_upn_slope_pipf, hig_upn_slope_z1585, hig_upn_slope_harmonic, hig_upn_slope_weighted, hig_upn_slope_linreg, hig_upn_elevationdrop_maxmin, hig_upn_elevationdrop_s1585, hig_upn_elevationdrop_pipf, hig_upn_elevationdrop_z1585, hig_upn_elevationdrop_harmonic, hig_upn_elevationdrop_weighted, hig_upn_elevationdrop_linreg,
+        hig_dra_tc_kirpicha, hig_dra_tc_georgeribeiro, hig_dra_tc_pasini, hig_dra_tc_ventura, hig_dra_tc_dnosk1,
+        
+        hig_upa_tc_kirpich, hig_upa_tc_dooge, hig_upa_tc_carter, hig_upa_tc_armycorps, hig_upa_tc_wattchow, hig_upa_tc_kirpicha,
+        hig_upa_tc_georgeribeiro, hig_upa_tc_pasini, hig_upa_tc_ventura, hig_upa_tc_dnosk1,
+        
+        hig_upn_elevation_avg, hig_upn_elevation_max, hig_upn_elevation_min, hig_upn_length_, hig_upn_length_km,
+        hig_upn_elevationdrop_m, hig_upn_slope_adim, hig_upn_slope_maxmin, hig_upn_slope_s1585, hig_upn_slope_pipf, hig_upn_slope_z1585, hig_upn_slope_harmonic, hig_upn_slope_weighted, hig_upn_slope_linreg, hig_upn_elevationdrop_maxmin, hig_upn_elevationdrop_s1585, hig_upn_elevationdrop_pipf, hig_upn_elevationdrop_z1585, hig_upn_elevationdrop_harmonic, hig_upn_elevationdrop_weighted, hig_upn_elevationdrop_linreg,
         hig_drn_annual_flow, hig_drn_event_flow, hig_drn_jobson_tpeak, hig_drn_jobson_tlead, hig_drn_jobson_tpeak_shortest, hig_drn_jobson_tlead_shortest,
         --hig_upn_gm, hig_upa_gm,
         hig_drn_reservoir_depth_m, hig_drn_reservoir_length_m,

--- a/pgh_hgm--2.2.4-tutorial.sql
+++ b/pgh_hgm--2.2.4-tutorial.sql
@@ -35,13 +35,14 @@ SELECT pgh_hgm.pghfn_tables_initialize();
 SELECT pgh_hgm.pghfn_prepro_calculate();
 
 -- declividades dos trechos
-SELECT pgh_hgm.pghfn_calculate_drn_slope_harmonic(55555, 5880);
-SELECT pgh_hgm.pghfn_calculate_drn_slope_linreg(55555, 5880);
 SELECT pgh_hgm.pghfn_calculate_drn_slope_maxmin(55555, 5880);
 SELECT pgh_hgm.pghfn_calculate_drn_slope_pipf(55555, 5880);
 SELECT pgh_hgm.pghfn_calculate_drn_slope_s1585(55555, 5880);
-SELECT pgh_hgm.pghfn_calculate_drn_slope_weighted(55555, 5880);
 SELECT pgh_hgm.pghfn_calculate_drn_slope_z1585(55555, 5880);
+SELECT pgh_hgm.pghfn_calculate_drn_slope_linreg(55555, 5880);
+SELECT pgh_hgm.pghfn_calculate_drn_slope_weighted(55555, 5880); 
+--SELECT pgh_hgm.pghfn_calculate_drn_slope_harmonic(55555, 5880); -- nao recomendada
+
 
 -- estatisticas do perfil de elevacao do trecho e elevation-drop
 SELECT pgh_hgm.pghfn_calculate_drn_elevationprofile_stats(55555, 5880);
@@ -99,13 +100,14 @@ SELECT pgh_hgm.pghfn_prepro_calculate_upa(55555, 5880);
 
 
 --- declividades do rio principal a montante
-SELECT pgh_hgm.pghfn_calculate_upn_slope_harmonic(55555, 5880); 
-SELECT pgh_hgm.pghfn_calculate_upn_slope_linreg(55555, 5880);
 SELECT pgh_hgm.pghfn_calculate_upn_slope_maxmin(55555, 5880); 
 SELECT pgh_hgm.pghfn_calculate_upn_slope_pipf(55555, 5880);
 SELECT pgh_hgm.pghfn_calculate_upn_slope_s1585(55555, 5880);
-SELECT pgh_hgm.pghfn_calculate_upn_slope_weighted(55555, 5880);
 SELECT pgh_hgm.pghfn_calculate_upn_slope_z1585(55555, 5880);
+SELECT pgh_hgm.pghfn_calculate_upn_slope_linreg(55555, 5880);
+SELECT pgh_hgm.pghfn_calculate_upn_slope_weighted(55555, 5880);
+-- SELECT pgh_hgm.pghfn_calculate_upn_slope_harmonic(55555, 5880); -- nao recomendada
+
 
 -- estatisticas do perfil de elevacao do rio a montante e elevation-drop
 SELECT pgh_hgm.pghfn_calculate_upn_elevationprofile_stats(55555, 5880);

--- a/pgh_hgm--2.2.4-tutorial.sql
+++ b/pgh_hgm--2.2.4-tutorial.sql
@@ -1,0 +1,162 @@
+
+TRAVA
+
+
+-- MOSTRA ALGUMAS COISAS
+--SELECT * FROM pgh_hgm.pghft_hydro_intel;
+--SELECT * FROM pgh_hgm.pghft_drn_elevationprofile;
+--SELECT * FROM pgh_hgm.pghft_upn_elevationprofile;
+
+
+-- TRUNCATE ELEVATION PROFILES
+--SELECT pgh_hgm.pghfn_utils_tmp_elevprof_truncate('drn');
+--SELECT pgh_hgm.pghfn_utils_tmp_elevprof_truncate('upn');
+
+-- EXPORTA RESULTADOS PARA 'geoft_bho_hgm'
+--SELECT pgh_hgm.pghfn_utils_export_output()
+
+------------------------------------------------------------------
+-- CONFIGURAR BANCO DE DADOS
+-- 0. conectar banco com schema pghydro
+-- 1. carregar extensao pgh_raster -> carregar pghrt_elevation
+-- 2. carregar extensao pgh_hgm
+------------------------------------------------------------------
+
+------------------------------------------------------------------
+-- INICIALIZA A TABELA DO PGH-HGM -> atualiza com dados do pghydro
+-------------------------------------------------------------------
+SELECT pgh_hgm.pghfn_tables_initialize();
+
+
+------------------------------------------------------------
+-- ESCALA LOCAL:  TRECHO (DRN) E BACIA (DRA)
+------------------------------------------------------------
+-- pre-processamento
+SELECT pgh_hgm.pghfn_prepro_calculate();
+
+-- declividades dos trechos
+SELECT pgh_hgm.pghfn_calculate_drn_slope_harmonic(55555, 5880);
+SELECT pgh_hgm.pghfn_calculate_drn_slope_linreg(55555, 5880);
+SELECT pgh_hgm.pghfn_calculate_drn_slope_maxmin(55555, 5880);
+SELECT pgh_hgm.pghfn_calculate_drn_slope_pipf(55555, 5880);
+SELECT pgh_hgm.pghfn_calculate_drn_slope_s1585(55555, 5880);
+SELECT pgh_hgm.pghfn_calculate_drn_slope_weighted(55555, 5880);
+SELECT pgh_hgm.pghfn_calculate_drn_slope_z1585(55555, 5880);
+
+-- estatisticas do perfil de elevacao do trecho e elevation-drop
+SELECT pgh_hgm.pghfn_calculate_drn_elevationprofile_stats(55555, 5880);
+SELECT pgh_hgm.pghfn_calculate_drn_elevationprofiledrop_from_slopes(55555, 5880);
+
+-- atributos do trecho
+SELECT pgh_hgm.pghfn_calculate_drn_sinuosity(55555, 5880);
+SELECT pgh_hgm.pghfn_calculate_drn_amhg_depth_width(55555, 5880); -- profundidade e largura
+
+-- atributos de bacia
+SELECT pgh_hgm.pghfn_calculate_dra_avglengthoverlandflow(55555, 5880);
+SELECT pgh_hgm.pghfn_calculate_dra_axislength(55555, 5880);
+SELECT pgh_hgm.pghfn_calculate_dra_circularity(55555, 5880);
+SELECT pgh_hgm.pghfn_calculate_dra_compacity(55555, 5880);
+SELECT pgh_hgm.pghfn_calculate_dra_drainagedensity(55555, 5880);
+SELECT pgh_hgm.pghfn_calculate_dra_formfactor(55555, 5880);
+SELECT pgh_hgm.pghfn_calculate_dra_hydrodensity(55555, 5880);
+SELECT pgh_hgm.pghfn_calculate_dra_perimeter(55555, 5880);
+SELECT pgh_hgm.pghfn_calculate_dra_shapefactor(55555, 5880);
+
+
+-- estatisticas de MDE da bacia
+SELECT pgh_hgm.pghfn_calculate_dra_elevations_stats(55555, 5880);  -- a operacao mais pesada!
+
+-- atributos com dependencia
+SELECT pgh_hgm.pghfn_calculate_dra_reachgradient(55555, 5880); -- utiliza hig_drn_slope_maxmin
+SELECT pgh_hgm.pghfn_calculate_dra_reliefratio(55555, 5880);  -- utiliza hig_dra_elevationdrop_m
+SELECT pgh_hgm.pghfn_calculate_dra_bonus_ring(55555, 5880);  -- utiliza hig_dra_elevationdrop_m
+SELECT pgh_hgm.pghfn_calculate_dra_bonus_river(55555, 5880);  -- utiliza hig_dra_elevationdrop_m
+SELECT pgh_hgm.pghfn_calculate_dra_bonus_schumm(55555, 5880);  -- utiliza hig_dra_elevationdrop_m
+
+
+--> Daqui pra baixo tambem ha dependencias
+--> no geral, areas, declividades, larguras, profundidades, etc.
+
+-- modelo de jobson
+SELECT pgh_hgm.pghfn_calculate_drn_jobson_initialize(55555, 5880);
+SELECT pgh_hgm.pghfn_calculate_drn_jobson_traveltime(55555, 5880);
+
+-- celeridades, velocidades, etc.
+SELECT pgh_hgm.pghfn_calculate_drn_wavetravel(55555, 5880);
+
+-- tempos de concentracao
+SELECT pgh_hgm.pghfn_calculate_dra_timeofconcentration(55555, 5880);
+SELECT pgh_hgm.pghfn_calculate_dra_kirpicha(55555, 5880);
+
+
+
+
+------------------------------------------------------------
+-- ESCALA DE MONTANTE:  TRECHO (UPN) E BACIA (UPA)
+------------------------------------------------------------
+-- pre-processamento
+SELECT pgh_hgm.pghfn_prepro_calculate_upa(55555, 5880);
+
+
+--- declividades do rio principal a montante
+SELECT pgh_hgm.pghfn_calculate_upn_slope_harmonic(55555, 5880); 
+SELECT pgh_hgm.pghfn_calculate_upn_slope_linreg(55555, 5880);
+SELECT pgh_hgm.pghfn_calculate_upn_slope_maxmin(55555, 5880); 
+SELECT pgh_hgm.pghfn_calculate_upn_slope_pipf(55555, 5880);
+SELECT pgh_hgm.pghfn_calculate_upn_slope_s1585(55555, 5880);
+SELECT pgh_hgm.pghfn_calculate_upn_slope_weighted(55555, 5880);
+SELECT pgh_hgm.pghfn_calculate_upn_slope_z1585(55555, 5880);
+
+-- estatisticas do perfil de elevacao do rio a montante e elevation-drop
+SELECT pgh_hgm.pghfn_calculate_upn_elevationprofile_stats(55555, 5880);
+SELECT pgh_hgm.pghfn_calculate_upn_elevationprofiledrop_from_slopes(55555, 5880); --utiliza hig_upn_slope_xxxx
+
+
+
+
+-- atributos do rio principal a montante
+SELECT pgh_hgm.pghfn_calculate_upn_sinuosity(55555, 5880); 
+
+-- atributos da bacia a montante
+SELECT pgh_hgm.pghfn_calculate_upa_avglengthoverlandflow(55555, 5880); 
+SELECT pgh_hgm.pghfn_calculate_upa_axislength(55555, 5880);
+SELECT pgh_hgm.pghfn_calculate_upa_circularity(55555, 5880); 
+SELECT pgh_hgm.pghfn_calculate_upa_compacity(55555, 5880); 
+SELECT pgh_hgm.pghfn_calculate_upa_drainagedensity(55555, 5880); 
+SELECT pgh_hgm.pghfn_calculate_upa_formfactor(55555, 5880); 
+SELECT pgh_hgm.pghfn_calculate_upa_hydrodensity(55555, 5880); 
+SELECT pgh_hgm.pghfn_calculate_upa_perimeter(55555, 5880);
+SELECT pgh_hgm.pghfn_calculate_upa_shapefactor(55555, 5880); 
+SELECT pgh_hgm.pghfn_calculate_upa_totaldrainagelength(55555, 5880);
+
+
+-- estatisticas do MDE a montante
+--SELECT pgh_hgm.pghfn_calculate_upa_elevations_stats(55555, 5880); -- a operacao mais pesada!
+SELECT pgh_hgm.pghfn_calculate_upa_elevations_stats_agg(); -- pelo metodo da agregacao
+
+
+-- atributos com dependencia
+SELECT pgh_hgm.pghfn_calculate_upa_reachgradient(55555, 5880); -- utiiza de hig_upn_slope_maxmin
+SELECT pgh_hgm.pghfn_calculate_upa_reliefratio(55555, 5880);  -- utiliza hig_upa_elevationdrop_m
+SELECT pgh_hgm.pghfn_calculate_upa_bonus_ring(55555, 5880);  -- utiliza hig_upa_elevationdrop_m
+SELECT pgh_hgm.pghfn_calculate_upa_bonus_river(55555, 5880);  -- utiliza hig_upa_elevationdrop_m
+SELECT pgh_hgm.pghfn_calculate_upa_bonus_schumm(55555, 5880);  -- utiliza hig_upa_elevationdrop_m
+
+--> Daqui pra baixo ha dependencias
+SELECT pgh_hgm.pghfn_calculate_upa_timeofconcentration(55555, 5880);
+SELECT pgh_hgm.pghfn_calculate_upa_kirpicha(55555, 5880);
+
+
+--> Copia os atributos de cabeceiras para upn/upa
+SELECT pgh_hgm.pghfn_postpro_updateheadwaters()
+
+
+/*
+SELECT
+hig_upa_elevation_max,hig_upa_elevation_min,hig_upa_elevation_avg,hig_upa_elevationdrop_m,
+hig_upa_reachgradient,
+hig_upa_reliefratio_ring,
+hig_upa_axislength_schumm,
+hig_upa_tc_kirpich
+FROM pgh_hgm.pghft_hydro_intel;
+*/

--- a/pgh_hgm.control
+++ b/pgh_hgm.control
@@ -1,6 +1,6 @@
  #pgh_hgm extension
 comment = 'pgh_hgm extension'
-default_version = '2.2.3'
+default_version = '2.2.4'
 encoding = 'latin1'
 requires = 'plpgsql'
 requires = 'postgis'


### PR DESCRIPTION
- controle de divisões por zero com NULLIF
- revisão de unidades em eq. de tempo de concentração novas
- small fix vírgula faltante entre atributos novos no update do calculate de tempo de concentração :/
- view geoft_ atualizada para incluir mais eq. de tempo de concentração
essas alterações não afetam outros processo.
- revisão pré-processamento (passando em linha de costa)
- nova função para calcular upa_elevation_stats por agregação para jusante